### PR TITLE
Fix kermit update on revision 2 boards

### DIFF
--- a/examples/firmware-update.c
+++ b/examples/firmware-update.c
@@ -153,7 +153,7 @@ int main(int argc, char * argv[])
 
             if (updateFirmware (_firmwareFile, progressCallback) == true)
             {
-                printf("Successfully update the firmware to %s\n", getFirmwareVersion());
+                printf("Successfully update the firmware, wait for the RockBLOCK 9704 to reboot\n");
             }
             else
             {

--- a/src/crossplatform.c
+++ b/src/crossplatform.c
@@ -18,4 +18,31 @@ char * stpncpy (char * dst, const char * src, size_t len)
     return strncpy (dst, src, len) + n;
 }
 
+unsigned long millis(void)
+{
+    return GetTickCount64();
+}
+
+void delay(uint32_t ms)
+{
+    Sleep(ms);
+}
+
+#elif defined(__linux__) || defined(__APPLE__)
+
+#include <time.h>
+#include <unistd.h>
+
+unsigned long millis(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+void delay(uint32_t ms)
+{
+    usleep(ms * 1000); // usleep takes microseconds
+}
+
 #endif

--- a/src/crossplatform.h
+++ b/src/crossplatform.h
@@ -17,8 +17,14 @@ extern "C" {
 
     char * stpncpy (char * dst, const char * src, size_t len);
 
-#endif
+    unsigned long millis(void);
+    void delay(uint32_t ms);
+#elif defined(__linux__) || defined(__APPLE__)
+    #include <stdint.h>
 
+    unsigned long millis(void);
+    void delay(uint32_t ms);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/crossplatform.h
+++ b/src/crossplatform.h
@@ -8,6 +8,7 @@ extern "C" {
 #if defined(_WIN32)
     #include <windows.h>
     #include <string.h>
+    #include <stdint.h>
 
     #ifndef PATH_MAX
         #define PATH_MAX MAX_PATH

--- a/src/jspr.c
+++ b/src/jspr.c
@@ -137,6 +137,34 @@ bool receiveJspr(jsprResponse_t * response, const char * expectedTarget)
     }
 }
 
+bool waitForJsprMessage(jsprResponse_t * response, const char * expectedTarget, const uint32_t expectedCode, const uint32_t timeoutSeconds)
+{
+    bool gotMessage = false;
+    unsigned long startTime = millis();
+
+    while (1)
+    {
+        receiveJspr(response, expectedTarget);
+
+        if (response->code == expectedCode &&
+            strncmp(response->target, expectedTarget, JSPR_MAX_TARGET_LENGTH) == 0)
+        {
+            gotMessage = true;
+            break;
+        }
+
+        if ((millis() - startTime) > timeoutSeconds * 1000)
+        {
+            gotMessage = false;
+            break;
+        }
+
+        delay(10);
+    }
+
+    return gotMessage;
+}
+
 void clearResponse(jsprResponse_t * response)
 {
     response->code = 0;

--- a/src/jspr.h
+++ b/src/jspr.h
@@ -288,6 +288,7 @@ typedef struct
 //internal functions
 int sendJspr(const char * buffer, size_t length);
 bool receiveJspr(jsprResponse_t * response, const char * expectedTarget);
+bool waitForJsprMessage(jsprResponse_t * response, const char * expectedTarget, const uint32_t expectedCode, const uint32_t timeoutSeconds);
 void clearResponse(jsprResponse_t * response);
 bool parseJsprBootInfo(const char * jsprString, jsprBootInfo_t * bootInfo);
 bool parseJsprGetApiVersion(char * jsprString, jsprApiVersion_t * apiVersion);

--- a/src/rockblock_9704.c
+++ b/src/rockblock_9704.c
@@ -972,7 +972,7 @@ bool updateFirmware (const char * firmwareFile, updateProgressCallback progress)
     if (kermitDone == true)
     {
         // Wait for 299 bootInfo
-        if (waitForJsprMessage(&response, "bootInfo", JSPR_RC_NO_ERROR, 10) == true)
+        if (waitForJsprMessage(&response, "bootInfo", JSPR_RC_UNSOLICITED_MESSAGE, 10) == true)
         {
             firmwareUpdated = parseJsprBootInfo(response.json, &bootInfo);
             setApi(); // Set the API so it is possible to command JSPR after

--- a/src/rockblock_9704.c
+++ b/src/rockblock_9704.c
@@ -186,13 +186,11 @@ static bool setSim(void)
                     {
                         parseJsprGetSimInterface(response.json, &simInterface);
 
-                        // Wait for simStatus to come back
-                        do
+                        // Wait for unsolicited simStatus to come back
+                        if (waitForJsprMessage(&response, "simStatus", JSPR_RC_UNSOLICITED_MESSAGE, 1) == true)
                         {
-                            receiveJspr(&response, "simStatus");
-                        } while ((JSPR_RC_UNSOLICITED_MESSAGE != response.code) &&
-                                 (strncmp(response.target, "simStatus", JSPR_MAX_TARGET_LENGTH) != 0));
-                        set = true;
+                            set = true;
+                        }
                     }
                 }
                 else if (JSPR_RC_NO_ERROR == response.code && simInterface.iface == INTERNAL)

--- a/src/rockblock_9704.c
+++ b/src/rockblock_9704.c
@@ -969,12 +969,11 @@ bool updateFirmware (const char * firmwareFile, updateProgressCallback progress)
 
     if (kermitDone == true)
     {
-        // Wait for 299 bootInfo
-        if (waitForJsprMessage(&response, "bootInfo", JSPR_RC_UNSOLICITED_MESSAGE, 10) == true)
-        {
-            firmwareUpdated = parseJsprBootInfo(response.json, &bootInfo);
-            setApi(); // Set the API so it is possible to command JSPR after
-        }
+        // Since board revision 2 (note that board revision 1 was never publicly available)
+        // When kermit is done, the 9704 modem will reboot, as a result the USB
+        // serial driver will disabled then re-enable, so we will need to re-enable
+        // the library for the new usb port, it might be different.
+        firmwareUpdated = true;
     }
 
     return firmwareUpdated;


### PR DESCRIPTION
Please note that revision 1 boards were never publically available.

When updating the 9704 modem it will enter kermit mode, once complete it will perform a reboot. Revision 2 board will disable a USB serial drive chip when the 9704 reboots.  As a result the USB serial driver will disabled then re-enable, so we will need to handle this in the firmware update. As the devnode will be unknown, I just decided to make it return true once done via kermit and leave the calling program to handle this.

While debugging this I added `waitForJsprMessage` function which is usefule when waiting for specific states. I.e. a 299 operationalState of being inactive.

I confirmed the build on Linux and Windows and verified the implementation on Linux.

