### PR TITLE
error: ordered comparison of pointer with integer zero

### DIFF
--- a/src/rockblock_9704.c
+++ b/src/rockblock_9704.c
@@ -310,7 +310,7 @@ static bool appendCrc(uint8_t * buffer, size_t length)
 {
     bool appended = false;
     int crc = calculateCrc(buffer, length, 0);
-    if (calculateCrc > 0)
+    if (crc > 0)
     {
         crcBuffer[0] = (crc >> 8) & 0xFFU;
         crcBuffer[1] = crc & 0xFFU;


### PR DESCRIPTION
Hey all!  I'm starting the process to integrate the 9704 & this library into our product.  When compiling with arm-non-eabi-gcc, I've come across this error: 

```
error: ordered comparison of pointer with integer zero [-Wpedantic]
  313 |     if (calculateCrc > 0)
      |                      ^

```

This comparison seems odd to me, and I believe maybe it was meant to be checking the crc value instead?  I've made this change in this PR, though I'm not yet familiar with how this new rockblock's CRC is expected to work.  

Alternatively, perhaps this used to check for a null function pointer, but has been refactored since?  In which case, this check should be removed entirely? 

Thanks!

       
      