### PR TITLE
Add preprocessor option for custom context's 

### DIFF
--- a/src/rockblock_9704.c
+++ b/src/rockblock_9704.c
@@ -47,6 +47,8 @@ jsprFirmwareInfo_t firmwareInfo;
     #define SERIAL_CONTEXT_SETUP_FUNC setContextWindows
 #elif ARDUINO
     #define SERIAL_CONTEXT_SETUP_FUNC setContextArduino
+#elif RB_CUSTOM_CONTEXT
+    #define SERIAL_CONTEXT_SETUP_FUNC setContextCustom
 #else
     #define SERIAL_CONTEXT_SETUP_FUNC //Custom approach
     #error A serial context is needed


### PR DESCRIPTION
As the 9704 library is currently implemented, those who may be trying to integrate this library into a platform that is not currently supported (ex. STM32, ESP32) may be forced to fork and directly modify this library to integrate with their own system.

This PR implements a compile-time option that allows for developers to build the library for a custom serial context.  This should prevent the need of forking and maintaining our own version of the library.  