### PR TITLE
Changed core include path in cmake to not depend on FW_UPDATE flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,10 @@ if (GPIO_ENABLED)
     target_link_libraries(${IRIDIUM_IMT_LIB} PUBLIC ${LIB_GPIOD_LIBRARIES})
 endif()
 
+target_include_directories(${IRIDIUM_IMT_LIB} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 if (DEFINED FW_UPDATE AND FW_UPDATE STREQUAL "ON")
     target_compile_definitions(${IRIDIUM_IMT_LIB} PUBLIC KERMIT)
     target_link_libraries(${IRIDIUM_IMT_LIB} PUBLIC ${KERMIT_LIB})
-    target_include_directories(${IRIDIUM_IMT_LIB} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${KERMIT_DIR} ${KERMIT_IO_DIR})
+    target_include_directories(${IRIDIUM_IMT_LIB} PUBLIC ${KERMIT_DIR} ${KERMIT_IO_DIR})
 endif()


### PR DESCRIPTION
The libraries core include path `${CMAKE_CURRENT_SOURCE_DIR}` would only ever be included if FW_UPDATE=ON, otherwise it would be missed. The flag has now been moved out of the conditional statement and is included separately during every build.

Fixes #52 