### PR TITLE
Fix incorrect type annotations

### DIFF
--- a/rockblock9704/rockblock.c
+++ b/rockblock9704/rockblock.c
@@ -286,7 +286,7 @@ static PyObject *py_rbBegin(PyObject *self, PyObject *args) {
 
     result = rbBegin(port);
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 
@@ -296,7 +296,7 @@ static PyObject *py_rbEnd(PyObject *self, PyObject *args) {
 
     result = rbEnd();
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 #ifdef RB_GPIO
@@ -354,7 +354,7 @@ static PyObject *py_rbBeginGpio(PyObject *self, PyObject *args) {
 
     result = rbBeginGpio(port, &gpioInfo, timeout);
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 
@@ -411,7 +411,7 @@ static PyObject *py_rbEndGpio(PyObject *self, PyObject *args) {
 
     result = rbEndGpio(&gpioInfo);
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 #endif
@@ -430,7 +430,7 @@ static PyObject *py_sendMessage(PyObject *self, PyObject *args) {
 
     result = rbSendMessage(data, length, timeout);
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 
@@ -449,7 +449,7 @@ static PyObject *py_sendMessageAny(PyObject *self, PyObject *args) {
 
     result = rbSendMessageAny(topic, data, length, timeout);
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 
@@ -467,7 +467,7 @@ static PyObject *py_sendMessageAsync(PyObject *self, PyObject *args) {
 
     result = rbSendMessageAsync(topic, data, length);
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 
@@ -539,7 +539,7 @@ static PyObject *py_rbAcknowledgeReceiveHeadAsync(PyObject *self, PyObject *args
 
     result = rbAcknowledgeReceiveHeadAsync();
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 
@@ -604,14 +604,14 @@ static PyObject *py_getBoardTemp(PyObject *self, PyObject *args) {
 static PyObject *py_getCardPresent(PyObject *self, PyObject *args) {
 
   int result = rbGetCardPresent();
-  return Py_BuildValue("i", result);
+  return PyBool_FromLong(result);
 
 }
 
 static PyObject *py_getSimConnected(PyObject *self, PyObject *args) {
 
   int result = rbGetSimConnected();
-  return Py_BuildValue("i", result);
+  return PyBool_FromLong(result);
 
 }
 
@@ -631,7 +631,7 @@ static PyObject *py_getFirmwareVersion(PyObject *self, PyObject *args) {
 
 static PyObject *py_resyncServiceConfig(PyObject *self, PyObject *args) {
   int result = rbResyncServiceConfig();
-  return Py_BuildValue("i", result);
+  return PyBool_FromLong(result);
 }
 
 static PyObject *py_cancelMessage(PyObject *self, PyObject *args) {
@@ -646,7 +646,7 @@ static PyObject *py_cancelMessage(PyObject *self, PyObject *args) {
 
     result = rbCancelMessage(topic, id);
 
-    return Py_BuildValue("i", result);
+    return PyBool_FromLong(result);
 
 }
 

--- a/rockblock9704/rockblock9704.py
+++ b/rockblock9704/rockblock9704.py
@@ -121,7 +121,7 @@ class RockBlock9704:
         if topic is not None:
             return _rb.send_message_async(topic, message)
 
-    def receive_message(self, topic: int = None) -> bytes:
+    def receive_message(self, topic: int = None) -> bytes | None:
         """
         Check for messages sent to the RockBLOCK 9704
         :param topic: optional to only get messages sent to this topic

--- a/rockblock9704/rockblock9704.py
+++ b/rockblock9704/rockblock9704.py
@@ -116,7 +116,7 @@ class RockBlock9704:
         Sends a message from the RockBLOCK 9704 asynchronously
         :param message: bytes to send
         :param topic: optional topic to send to (defaults to raw topic)
-        :return: boolean indicating success
+        :return: boolean indicating success or None
         """
         if topic is not None:
             return _rb.send_message_async(topic, message)
@@ -125,7 +125,7 @@ class RockBlock9704:
         """
         Check for messages sent to the RockBLOCK 9704
         :param topic: optional to only get messages sent to this topic
-        :return: byte string message
+        :return: byte string message or None
         """
         if topic is None:
             return _rb.receive_message()
@@ -136,7 +136,7 @@ class RockBlock9704:
         """
         Check asynchronously for messages sent to the RockBLOCK 9704
         :param topic: optional to only get messages sent to this topic
-        :return: byte string message
+        :return: byte string message or None
         """
         if topic is None:
             return _rb.receive_message_async()
@@ -218,24 +218,24 @@ class RockBlock9704:
         """
         return _rb.set_mo_message_started_callback(mo_message_started)
 
-    def get_hardware_version(self) -> str:
+    def get_hardware_version(self) -> str | None:
         """
         Get RockBLOCK 9704 hardware version
-        :return: version string
+        :return: version string or None
         """
         return _rb.get_hardware_version()
 
-    def get_serial_number(self) -> str:
+    def get_serial_number(self) -> str | None:
         """
         Get RockBLOCK 9704 serial number
-        :return: serial string
+        :return: serial string or None
         """
         return _rb.get_serial_number()
 
-    def get_imei(self) -> str:
+    def get_imei(self) -> str | None:
         """
         Get modem IMEI
-        :return: IMEI string
+        :return: IMEI string or None
         """
         return _rb.get_imei()
 
@@ -260,10 +260,10 @@ class RockBlock9704:
         """
         return _rb.get_sim_connected()
 
-    def get_iccid(self) -> str:
+    def get_iccid(self) -> str | None:
         """
         Get ICCID of SIM
-        :return: ICCID string
+        :return: ICCID string or None
         """
         return _rb.get_iccid()
 
@@ -286,7 +286,7 @@ class RockBlock9704:
         Cancels a message which has already been accepted by the modem.
         :param topic: topic used to send the message
         :param id: message ID obtained from the mo_message_started callback
-        :return: bool depicting whether the command to cancel the message has been sent successfully
+        :return: bool depicting whether the command to cancel the message has been sent successfully or None
         """
         if topic is not None and id is not None:
             return _rb.cancel_message(topic, id)

--- a/rockblock9704/rockblock9704.py
+++ b/rockblock9704/rockblock9704.py
@@ -111,7 +111,7 @@ class RockBlock9704:
         else:
             return _rb.send_message_any(topic, message, timeout)
 
-    def send_message_async(self, message: bytes, topic: int = None) -> bool:
+    def send_message_async(self, message: bytes, topic: int = None) -> bool | None:
         """
         Sends a message from the RockBLOCK 9704 asynchronously
         :param message: bytes to send
@@ -132,7 +132,7 @@ class RockBlock9704:
         else:
             return _rb.receive_message_with_topic(topic)
         
-    def receive_message_async(self, topic: int = None) -> bytes:
+    def receive_message_async(self, topic: int = None) -> bytes | None:
         """
         Check asynchronously for messages sent to the RockBLOCK 9704
         :param topic: optional to only get messages sent to this topic
@@ -281,7 +281,7 @@ class RockBlock9704:
         """
         return _rb.resync_service_config()
 
-    def cancel_message(self, topic: int = None, id: int = None) -> bool:
+    def cancel_message(self, topic: int = None, id: int = None) -> bool | None:
         """
         Cancels a message which has already been accepted by the modem.
         :param topic: topic used to send the message


### PR DESCRIPTION
This should fix #71 .
I'm also considering creating a `.pyi` file for the `_rb` functions to provide a greater guarantee of correctness, but that's also prone to human error, and I don't know if that's something you would be interested in.